### PR TITLE
chore(deps): upgrade to pnpm 11

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     timeout-minutes: 15
     strategy:
       matrix:
-        node-version: [22,25]
+        node-version: [22,24,26]
         nextjs-version: [15,16]
         os: [ubuntu-latest]
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Setup Biome
         uses: biomejs/setup-biome@v2
         with:
-          version: latest
+          version: 2.4.6
       - name: Run Biome
         run: biome ci .
   Types:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     timeout-minutes: 15
     strategy:
       matrix:
-        node-version: [20,22,25]
+        node-version: [22,25]
         nextjs-version: [15,16]
         os: [ubuntu-latest]
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,24 +28,7 @@ jobs:
       - run: pnpm i  && pnpm build
       - run: pnpm add next@^${{ matrix.nextjs-version }}
       - name: Install Playwright browsers
-        if: ${{ matrix.node-version != 26 }}
         run: pnpm playwright install --with-deps
-      # Playwright 1.58 hangs while extracting browsers under Node 26.
-      - name: Use Node 24 for Playwright browser installation
-        if: ${{ matrix.node-version == 26 }}
-        uses: actions/setup-node@v6
-        with:
-          node-version: 24
-          cache: pnpm
-      - name: Install Playwright browsers for Node 26 tests
-        if: ${{ matrix.node-version == 26 }}
-        run: pnpm playwright install --with-deps
-      - name: Restore Node 26 for tests
-        if: ${{ matrix.node-version == 26 }}
-        uses: actions/setup-node@v6
-        with:
-          node-version: 26
-          cache: pnpm
       - run: pnpm test
         env:
           CI: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,25 @@ jobs:
       - run: cd next-app-mock && pnpm i
       - run: pnpm i  && pnpm build
       - run: pnpm add next@^${{ matrix.nextjs-version }}
-      - run: pnpm playwright install --with-deps
+      - name: Install Playwright browsers
+        if: ${{ matrix.node-version != 26 }}
+        run: pnpm playwright install --with-deps
+      # Playwright 1.58 hangs while extracting browsers under Node 26.
+      - name: Use Node 24 for Playwright browser installation
+        if: ${{ matrix.node-version == 26 }}
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: pnpm
+      - name: Install Playwright browsers for Node 26 tests
+        if: ${{ matrix.node-version == 26 }}
+        run: pnpm playwright install --with-deps
+      - name: Restore Node 26 for tests
+        if: ${{ matrix.node-version == 26 }}
+        uses: actions/setup-node@v6
+        with:
+          node-version: 26
+          cache: pnpm
       - run: pnpm test
         env:
           CI: true

--- a/__tests__/ScrollRestorer.spec.ts
+++ b/__tests__/ScrollRestorer.spec.ts
@@ -64,7 +64,7 @@ const initTests = async (page: Page) => {
 	await expectScrollToBe(page, 0);
 	await page.goBack();
 };
-test('End to end testing of scroll restorer', async ({ page, browserName }) => {
+test('End to end testing of scroll restorer', async ({ page }) => {
 	await initTests(page);
 	await expect(page).toHaveURL('/');
 	await resolveTimeout(1000); //Check if Next.js does not brake scroll position later
@@ -122,9 +122,6 @@ test('End to end testing of scroll restorer', async ({ page, browserName }) => {
 	await expectScrollToBe(page, mainPage);
 
 	await page.reload();
-	if (browserName === 'firefox') {
-		await page.goBack(); //Firefox pushed new history entry history after reload https://github.com/microsoft/playwright/issues/22640
-	}
 	await resolveTimeout(1000); //Sometimes browsers struggle to restore the same millisecond
 	await expectScrollToBe(page, mainPage);
 

--- a/next-app-mock/pnpm-workspace.yaml
+++ b/next-app-mock/pnpm-workspace.yaml
@@ -1,3 +1,3 @@
-onlyBuiltDependencies:
-  - sharp
-  - unrs-resolver
+allowBuilds:
+  sharp: true
+  unrs-resolver: true

--- a/package.json
+++ b/package.json
@@ -54,11 +54,6 @@
 		"tsup": "^8.5.1",
 		"typescript": "^5.9.3"
 	},
-	"pnpm": {
-		"overrides": {
-			"@playwright/test": "1.58.2"
-		}
-	},
 	"peerDependencies": {
 		"next": "^15.0 || ^16.0",
 		"react": "^19.0"

--- a/package.json
+++ b/package.json
@@ -63,5 +63,5 @@
 		"next": "^15.0 || ^16.0",
 		"react": "^19.0"
 	},
-	"packageManager": "pnpm@10.32.1"
+	"packageManager": "pnpm@11.21.0"
 }

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
 	"devDependencies": {
 		"@biomejs/biome": "2.4.6",
 		"@changesets/cli": "^2.30.0",
-		"@playwright/test": "1.58.2",
+		"@playwright/test": "1.62.1",
 		"@swc/core": "^1.15.18",
 		"@types/node": "^24.12.0",
 		"@types/react": "^19.2.14",

--- a/package.json
+++ b/package.json
@@ -37,8 +37,8 @@
 		"prepare": "pnpm build",
 		"test": "pnpm lint && pnpm tsc && pnpm unit",
 		"unit": "playwright test",
-		"lint": "pnpx @biomejs/biome check",
-		"lint:fix": "pnpx @biomejs/biome format --write"
+		"lint": "biome check",
+		"lint:fix": "biome format --write"
 	},
 	"bugs": {
 		"url": "https://github.com/RevoTale/next-scroll-restorer/issues"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ importers:
     dependencies:
       next:
         specifier: ^15.0 || ^16.0
-        version: 16.1.6(@playwright/test@1.58.2)(react-dom@19.2.0(react@19.2.4))(react@19.2.4)
+        version: 16.1.6(@playwright/test@1.62.1)(react-dom@19.2.0(react@19.2.4))(react@19.2.4)
       react:
         specifier: ^19.0
         version: 19.2.4
@@ -22,8 +22,8 @@ importers:
         specifier: ^2.30.0
         version: 2.30.0(@types/node@24.12.0)
       '@playwright/test':
-        specifier: 1.58.2
-        version: 1.58.2
+        specifier: 1.62.1
+        version: 1.62.1
       '@swc/core':
         specifier: ^1.15.18
         version: 1.15.18
@@ -569,9 +569,9 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
-  '@playwright/test@1.58.2':
-    resolution: {integrity: sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==}
-    engines: {node: '>=18'}
+  '@playwright/test@1.62.1':
+    resolution: {integrity: sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==}
+    engines: {node: '>=20'}
     hasBin: true
 
   '@rollup/rollup-android-arm-eabi@4.59.0':
@@ -1168,14 +1168,14 @@ packages:
   pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
 
-  playwright-core@1.58.2:
-    resolution: {integrity: sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==}
-    engines: {node: '>=18'}
+  playwright-core@1.62.1:
+    resolution: {integrity: sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==}
+    engines: {node: '>=20'}
     hasBin: true
 
-  playwright@1.58.2:
-    resolution: {integrity: sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==}
-    engines: {node: '>=18'}
+  playwright@1.62.1:
+    resolution: {integrity: sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==}
+    engines: {node: '>=20'}
     hasBin: true
 
   postcss-load-config@6.0.1:
@@ -1829,9 +1829,9 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
 
-  '@playwright/test@1.58.2':
+  '@playwright/test@1.62.1':
     dependencies:
-      playwright: 1.58.2
+      playwright: 1.62.1
 
   '@rollup/rollup-android-arm-eabi@4.59.0':
     optional: true
@@ -2234,7 +2234,7 @@ snapshots:
 
   nanoid@3.3.11: {}
 
-  next@16.1.6(@playwright/test@1.58.2)(react-dom@19.2.0(react@19.2.4))(react@19.2.4):
+  next@16.1.6(@playwright/test@1.62.1)(react-dom@19.2.0(react@19.2.4))(react@19.2.4):
     dependencies:
       '@next/env': 16.1.6
       '@swc/helpers': 0.5.15
@@ -2253,7 +2253,7 @@ snapshots:
       '@next/swc-linux-x64-musl': 16.1.6
       '@next/swc-win32-arm64-msvc': 16.1.6
       '@next/swc-win32-x64-msvc': 16.1.6
-      '@playwright/test': 1.58.2
+      '@playwright/test': 1.62.1
       sharp: 0.34.5
     transitivePeerDependencies:
       - '@babel/core'
@@ -2307,11 +2307,11 @@ snapshots:
       mlly: 1.8.1
       pathe: 2.0.3
 
-  playwright-core@1.58.2: {}
+  playwright-core@1.62.1: {}
 
-  playwright@1.58.2:
+  playwright@1.62.1:
     dependencies:
-      playwright-core: 1.58.2
+      playwright-core: 1.62.1
     optionalDependencies:
       fsevents: 2.3.2
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,9 +4,6 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-overrides:
-  '@playwright/test': 1.58.2
-
 importers:
 
   .:
@@ -1089,7 +1086,7 @@ packages:
     hasBin: true
     peerDependencies:
       '@opentelemetry/api': ^1.1.0
-      '@playwright/test': 1.58.2
+      '@playwright/test': ^1.51.1
       babel-plugin-react-compiler: '*'
       react: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
       react-dom: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,7 @@
+overrides:
+  '@playwright/test': 1.58.2
+
+allowBuilds:
+  '@swc/core': true
+  esbuild: true
+  sharp: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,3 @@
-overrides:
-  '@playwright/test': 1.58.2
-
 allowBuilds:
   '@swc/core': true
   esbuild: true


### PR DESCRIPTION
## Summary

- upgrade the project package manager to pnpm 11
- migrate root and fixture build approvals to `allowBuilds`
- remove the obsolete Playwright override after regenerating the lockfile
- test every Node.js version supported by pnpm 11 (22, 24, and 26)
- pin CI and package scripts to the repository's Biome version
- upgrade Playwright to 1.62.1 so browser installation runs directly on Node 26
- remove the obsolete Firefox reload workaround for microsoft/playwright#22640

pnpm 11 reads project settings from `pnpm-workspace.yaml` and replaces legacy build approvals with `allowBuilds`: https://pnpm.io/settings and https://pnpm.io/settings/build#allowbuilds

The Playwright upgrade avoids the Node 26 browser-extraction hang tracked in microsoft/playwright#40724.

## Validation

- local Debian Node 26 run: Playwright browser installation completed and all 18 tests passed
- GitHub Actions passed lint, types, and tests on Node.js 22/24/26 with Next.js 15/16